### PR TITLE
Change localhost:8080 to localhost:10001 in template README

### DIFF
--- a/template/base/README.md
+++ b/template/base/README.md
@@ -14,4 +14,4 @@ Start the application with
 npm start
 ```
 
-and go to [localhost:8080](http://localhost:8080) to see the application running
+and go to [localhost:10001](http://localhost:10001) to see the application running


### PR DESCRIPTION
Hey 👋

I've just generated new huncwot project and encountered a mismatch between README and what happens. I believe that the port comes (leaks?) from the defaults of [rollup-plugin-serve](https://github.com/calebdwilliams/rollup-plugin-serve).

A long term fix might be to override the port in [/config/client/rollup.config.js#L27](https://github.com/huncwotjs/huncwot/blob/master/template/base/config/client/rollup.config.js#L27).

