### PR TITLE
fix: ensure correct huncwot version in templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "test": "ava",
-    "debug": "node --inspect cli.js"
+    "debug": "node --inspect cli.js",
+    "prepack": "node scripts/prepack"
   },
   "peerDependencies": {
     "axios": "^0.19.2"

--- a/scripts/prepack.js
+++ b/scripts/prepack.js
@@ -1,0 +1,21 @@
+const { writeFileSync, readFileSync } = require('fs');
+const { join } = require('path');
+
+const prettier = require('prettier');
+
+const mainPackageJson = require('../package.json');
+
+/**
+ * @param {string} templatePath
+ */
+function setVersionInTemplate(templatePath) {
+  const packagePath = join(templatePath, 'package.json');
+
+  const pkg = JSON.parse(readFileSync(packagePath, { encoding: 'utf-8' }));
+  pkg.dependencies.huncwot = `^${mainPackageJson.version}`;
+  const text = prettier.format(JSON.stringify(pkg), { filepath: packagePath, ...mainPackageJson.prettier });
+
+  writeFileSync(packagePath, text, { encoding: 'utf-8' });
+}
+
+setVersionInTemplate(join(__dirname, '../template/base'));

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -4,7 +4,7 @@
     "start": "stmux -w always -e ERROR -m beep,system -- [ -t 'Client' 'huncwot client' .. -t 'Server' 'huncwot server' ]"
   },
   "dependencies": {
-    "huncwot": "0.53.1"
+    "huncwot": "^0.53.1"
   },
   "snowpack": {
     "webDependencies": []


### PR DESCRIPTION
We run prettier instead of adding newlines in JSON.stringify to ensure
consistency when the file is edited by a human.

The function declaration is a bit YAGNI, but something felt off when I wrote this inline.
Feel free to edit my PR.

Closes #54