### PR TITLE
Add a render method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,6 +2051,11 @@
       "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "debug": "^4.1.1",
     "dumper.js": "^1.3.1",
     "error-stack-parser": "^2.0.6",
+    "escape-html": "^1.0.3",
     "fast-glob": "3.2.2",
     "fs-extra": "^8.1.0",
     "graphile-worker": "^0.5.0",

--- a/render.js
+++ b/render.js
@@ -1,0 +1,29 @@
+// Copyright 2020 Zaiste & contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const { join } = require('path');
+const { compile } = require('pure-engine');
+const escape = require('escape-html');
+
+const cwd = process.cwd();
+
+const render = async (source, context) => {
+  const { template } = await compile(source, {
+    paths: ['.', join(cwd, 'views')]
+  });
+  return template(context, escape);
+}
+
+module.exports = {
+  render
+}

--- a/render.spec.js
+++ b/render.spec.js
@@ -1,0 +1,17 @@
+const test = require('ava');
+const { render } = require('./render');
+
+test('it renders html', async assert => {
+  const source = '<div>{foo}</div>';
+  const context = { foo: 'Hello, world!' };
+  const html = await render(source, context);
+  assert.deepEqual(html, '<div>Hello, world!</div>');
+});
+
+test('it escapes html', async assert => {
+  const source = '<div>{foo}</div>';
+  const context = { foo: '<script>alert(42);</script>' };
+  const html = await render(source, context);
+  assert.deepEqual(html, '<div>&lt;script&gt;alert(42);&lt;/script&gt;</div>');
+});
+

--- a/response.js
+++ b/response.js
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 const { join } = require('path');
-const { compile } = require('pure-engine');
 const fs = require('fs-extra');
+const { render } = require('./render')
 
 const cwd = process.cwd();
 // TODO auto-create those functions?
@@ -116,11 +116,8 @@ const Page = async (location, context) => {
 
   const path = feature ? join(cwd, 'features', feature, 'Page', `${name}.html`) : join(cwd, 'views', `${name}.html`);
   const content = await fs.readFile(path);
-
-  const { template } = await compile(content.toString(), {
-    paths: ['.', join(cwd, 'views')]
-  });
-  return HTMLString(template(context, _ => _));
+  const html = await render(content.toString(), context);
+  return HTMLString(html);
 };
 
 module.exports = {


### PR DESCRIPTION
## Context

The PR adds the missing `escape-html` dependency and some specs. The project does not seem to have a strong convention for tests yet so I'm proposing an approach I'm using in own projects.

The convention is:

1) local specs (e.g. `render.js` -> `render.spec.js` | `response.js` -> `response.spec.js`)
2) global specs (e.g. `test/index.js`)