### PR TITLE
Page accepts different locations

### DIFF
--- a/render.js
+++ b/render.js
@@ -11,15 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { join } = require('path');
 const { compile } = require('pure-engine');
 const escape = require('escape-html');
 
-const cwd = process.cwd();
-
-const render = async (source, context) => {
+const render = async (source, options = {}) => {
+  const { context = {}, paths = [] } = options
   const { template } = await compile(source, {
-    paths: ['.', join(cwd, 'views')]
+    paths: ['.', ...paths]
   });
   return template(context, escape);
 }

--- a/render.spec.js
+++ b/render.spec.js
@@ -1,17 +1,34 @@
 const test = require('ava');
 const { render } = require('./render');
+const { join } = require('path');
+const { tmpdir } = require('os');
+const { writeFile } = require('fs-extra');
 
 test('it renders html', async assert => {
+  const source = '<div>foo</div>';
+  const html = await render(source);
+  assert.deepEqual(html, '<div>foo</div>');
+});
+
+test('it accepts context', async assert => {
   const source = '<div>{foo}</div>';
   const context = { foo: 'Hello, world!' };
-  const html = await render(source, context);
+  const html = await render(source, { context });
   assert.deepEqual(html, '<div>Hello, world!</div>');
 });
 
 test('it escapes html', async assert => {
   const source = '<div>{foo}</div>';
   const context = { foo: '<script>alert(42);</script>' };
-  const html = await render(source, context);
+  const html = await render(source, { context });
   assert.deepEqual(html, '<div>&lt;script&gt;alert(42);&lt;/script&gt;</div>');
 });
 
+test('it accepts paths', async assert => {
+  const source = '<import foo from="./foo.html"/><foo/>';
+  const dir = tmpdir()
+  const path = join(dir, 'foo.html')
+  await writeFile(path, 'bar')
+  const html = await render(source, { paths: [dir] })
+  assert.deepEqual(html, 'bar')
+})

--- a/response.spec.js
+++ b/response.spec.js
@@ -1,0 +1,16 @@
+const test = require('ava');
+const { Page } = require('./response');
+const { tmpdir } = require('os');
+const { join } = require('path');
+const { writeFile } = require('fs-extra');
+
+test('Page renders html', async assert => {
+  const dir = tmpdir();
+  const path = join(dir, 'response-test.html');
+  await writeFile(path, '<div>{foo}</div>');
+  const response = await Page(path, { foo: 'bar' });
+  const { statusCode, type, body } = response;
+  assert.deepEqual(statusCode, 200);
+  assert.deepEqual(type, 'text/html');
+  assert.deepEqual(body, '<div>bar</div>');
+});


### PR DESCRIPTION
## Context

The developer should be able to import local components, relative to the location of the template used in the controller.

## Example

features/Base/Page/index.html

```
<import foo from="components/foo.html"/>
<foo/>
```

features/Base/Page/components/foo.html

```html
<div>bar</div>
```

controller

```
await Page('index@Base')
```