### PR TITLE
Simplify the prepack script to utilize JSON.stringify formatting

### DIFF
--- a/scripts/prepack.js
+++ b/scripts/prepack.js
@@ -1,24 +1,10 @@
-const { writeFileSync, readFileSync } = require('fs');
-const { join } = require('path');
+const { writeFileSync } = require('fs');
+const { join } = require('path')
+const { version } = require('../package.json');
 
-const prettier = require('prettier');
+const packagePath = join(__dirname, '../template/base/package.json')
+const pkg = require(packagePath);
 
-const mainPackageJson = require('../package.json');
-
-/**
- * @param {string} templatePath
- */
-function setVersionInTemplate(templatePath) {
-  const packagePath = join(templatePath, 'package.json');
-
-  const pkg = JSON.parse(readFileSync(packagePath, { encoding: 'utf-8' }));
-  pkg.dependencies.huncwot = `^${mainPackageJson.version}`;
-  const text = prettier.format(JSON.stringify(pkg), {
-    filepath: packagePath,
-    ...mainPackageJson.prettier
-  });
-
-  writeFileSync(packagePath, text, { encoding: 'utf-8' });
-}
-
-setVersionInTemplate(join(__dirname, '../template/base'));
+pkg.dependencies.huncwot = `^${version}`;
+const content = JSON.stringify(pkg, null, 2) + "\n";
+writeFileSync(packagePath, content, { encoding: 'utf-8' });


### PR DESCRIPTION
## Context

`JSON.stringify` has a formatting option, which is good enough for json formatting. There is no need to use prettier for it (which is quite big and takes some time to load).

## How was this tested?

Running `node scripts/prepack.js` in the cli generates a file with same formatting, `git status` and/or `git diff` do not give any results.