### PR TITLE
Cached templates

### DIFF
--- a/filesystem.js
+++ b/filesystem.js
@@ -1,0 +1,15 @@
+const { readFile } = require('fs-extra');
+
+const memory = {}
+
+const read = async (path, options = {}) => {
+  const { cache } = options
+  if (cache && memory[path]) { return new Promise(resolve => resolve(memory[path])) }
+  const content = await readFile(path, { encoding: 'utf-8' })
+  if (cache) { memory[path] = content }
+  return content
+}
+
+module.exports = {
+  read
+}

--- a/filesystem.spec.js
+++ b/filesystem.spec.js
@@ -1,0 +1,29 @@
+const test = require('ava');
+const { join } = require('path');
+const { tmpdir } = require('os');
+const { writeFileSync, unlinkSync } = require('fs');
+const { read } = require('./filesystem');
+
+test('it returns data from cache', async assert => {
+  const dir = tmpdir();
+  const filepath = join(dir, 'filesystem-test-cache-true.html');
+  writeFileSync(filepath, '<div>foo</div>');
+  const content1 = await read(filepath, { cache: true });
+  assert.deepEqual(content1, '<div>foo</div>');
+  writeFileSync(filepath, '<div>bar</div>');
+  const content2 = await read(filepath, { cache: true });
+  assert.deepEqual(content2, '<div>foo</div>');
+  unlinkSync(filepath);
+});
+
+test('it reads data multiple time without cache', async assert => {
+  const dir = tmpdir();
+  const filepath = join(dir, 'filesystem-test-cache-false.html');
+  writeFileSync(filepath, '<div>foo</div>');
+  const content1 = await read(filepath, { cache: false });
+  assert.deepEqual(content1, '<div>foo</div>');
+  writeFileSync(filepath, '<div>bar</div>');
+  const content2 = await read(filepath, { cache: false });
+  assert.deepEqual(content2, '<div>bar</div>');
+  unlinkSync(filepath);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4349,9 +4349,9 @@
       "integrity": "sha512-vTau7lb9dkhwKw1GX3vd98zzF1K7qBvFyPZMiyaBds3N0Yste4ZUA7Kt9oIzeJtKcG8hdWK0PMZQM2Ahi3PPrQ=="
     },
     "pure-engine": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/pure-engine/-/pure-engine-0.15.5.tgz",
-      "integrity": "sha512-K1WREo33GBfcvpotdGg7H31iPPpWAv7TNKVN4t2wOVFiW4709elBky0zt2U5iiZXkp2jl+1Cr+SMoQ6i3n8jHw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/pure-engine/-/pure-engine-0.16.0.tgz",
+      "integrity": "sha512-gFtc63d8xUCrV5/Pw3kw3Ey+jmTH60VCgSBrgFB3lYjRrnLCdhMRiBU3Wg+GBn7FNuH990nXae2HQmWznUl8TQ==",
       "requires": {
         "abstract-syntax-tree": "^2.5.0",
         "astoptech": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mime-types": "^2.1.26",
     "nearley": "^2.19.1",
     "pg": "^7.18.2",
-    "pure-engine": "^0.15.5",
+    "pure-engine": "^0.16.0",
     "rsyncwrapper": "^3.0.1",
     "semver": "^7.1.3",
     "stack-trace": "0.0.10",

--- a/response.js
+++ b/response.js
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 const { dirname, join } = require('path');
-const fs = require('fs-extra');
+const { read } = require('./filesystem');
 const { render } = require('./view');
 
 const cwd = process.cwd();
@@ -111,11 +111,13 @@ const InternalServerError = message => {
   };
 };
 
+const cache = process.env.NODE_ENV === 'production';
+
 const Page = async (location, context) => {
   if (location.endsWith('.html')) {
     const dir = dirname(location);
     const paths = [dir];
-    const content = await fs.readFile(location);
+    const content = await read(location, { cache });
     const html = await render(content.toString(), { context, paths });
     return HTMLString(html);
   } else if (location.includes('@')) {
@@ -124,14 +126,14 @@ const Page = async (location, context) => {
     const dir = join(cwd, 'features', feature, 'Page');
     const path = join(dir, `${name}.html`);
     const paths = [dir, views];
-    const content = await fs.readFile(path);
+    const content = await read(path, { cache });
     const html = await render(content.toString(), { context, paths });
     return HTMLString(html);
   } else {
     const views = join(cwd, 'views');
     const path = join(views, `${location}.html`);
     const paths = [views];
-    const content = await fs.readFile(path);
+    const content = await read(path, { cache });
     const html = await render(content.toString(), { context, paths });
     return HTMLString(html);
   }

--- a/view.js
+++ b/view.js
@@ -17,6 +17,7 @@ const escape = require('escape-html');
 const render = async (source, options = {}) => {
   const { context = {}, paths = [] } = options
   const { template } = await compile(source, {
+    cache: process.env.NODE_ENV === 'production',
     paths: ['.', ...paths]
   });
   return template(context, escape);


### PR DESCRIPTION
## Context

Right now we're reading/compiling every time. It's ok for development, but not ideal for production.

I've updated the engine to have an internal cache, so we don't have to implement it here.

Reading from filesystem is another problem, so I've added a tiny wrapper. Didn't want to use yet another library for file reading and fs-extra does not cache out of the box. Could potentially get rid of fs-extra and just implement few fns here, only few functions are used.